### PR TITLE
Handle asynchronous uncaught errors with domains

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -16,6 +16,7 @@
 var async    = require('../deps/async'), //@REMOVE_LINE_FOR_BROWSER
     nodeunit = require('./nodeunit'),    //@REMOVE_LINE_FOR_BROWSER
     types    = require('./types');       //@REMOVE_LINE_FOR_BROWSER
+    domain   = require('domain');        //@REMOVE_LINE_FOR_BROWSER
 
 
 /**
@@ -66,12 +67,19 @@ exports.runTest = function (name, fn, opt, callback) {
     var test = types.test(name, start, options, callback);
 
     options.testReady(test);
-    try {
-        fn(test);
-    }
-    catch (e) {
-        test.done(e);
-    }
+
+    var d = domain.create();      //@REMOVE_LINE_FOR_BROWSER
+    d.run(function() {            //@REMOVE_LINE_FOR_BROWSER
+        try {
+            fn(test);
+        }
+        catch (e) {
+            test.done(e);
+        }
+    });                           //@REMOVE_LINE_FOR_BROWSER
+    d.on('error', function(e) {   //@REMOVE_LINE_FOR_BROWSER
+        test.done(e);             //@REMOVE_LINE_FOR_BROWSER
+    });                           //@REMOVE_LINE_FOR_BROWSER
 };
 
 /**

--- a/lib/types.js
+++ b/lib/types.js
@@ -106,11 +106,29 @@ exports.test = function (name, start, options, callback) {
     var expecting;
     var a_list = [];
 
+    var log, testDone;
+    if (options.log) {
+        log = function() {
+            try {
+                options.log.apply(this, arguments);
+            } catch (error) {
+                //ignore callback errors
+            }
+        };
+    }
+    testDone = function() {
+        try {
+            options.testDone.apply(this, arguments);
+        } catch (error) {
+            //ignore callback errors
+        }
+    };
+
     var wrapAssert = assertWrapper(function (a) {
         a_list.push(a);
-        if (options.log) {
+        if (log) {
             async.nextTick(function () {
-                options.log(a);
+                log(a);
             });
         }
     });
@@ -124,25 +142,25 @@ exports.test = function (name, start, options, callback) {
                 );
                 var a1 = exports.assertion({method: 'expect', error: e});
                 a_list.push(a1);
-                if (options.log) {
+                if (log) {
                     async.nextTick(function () {
-                        options.log(a1);
+                        log(a1);
                     });
                 }
             }
             if (err) {
                 var a2 = exports.assertion({error: err});
                 a_list.push(a2);
-                if (options.log) {
+                if (log) {
                     async.nextTick(function () {
-                        options.log(a2);
+                        log(a2);
                     });
                 }
             }
             var end = new Date().getTime();
             async.nextTick(function () {
                 var assertion_list = exports.assertionList(a_list, end - start);
-                options.testDone(name, assertion_list);
+                testDone(name, assertion_list);
                 callback(null, a_list);
             });
         },

--- a/test/test-runtest.js
+++ b/test/test-runtest.js
@@ -44,3 +44,22 @@ exports.testThrowError = function (test) {
         }
     }, test.done);
 };
+
+exports.testThrowErrorAsync = function (test) {
+    test.expect(3);
+    var err = new Error('test');
+    var testfn = function (test) {
+        process.nextTick(function() {
+            throw err;
+        });
+    };
+    nodeunit.runTest('testname', testfn, {
+        log: function (assertion) {
+            test.same(assertion.error, err, 'assertion.error');
+        },
+        testDone: function (name, assertions) {
+            test.equals(assertions.failures(), 1);
+            test.equals(assertions.length, 1);
+        }
+    }, test.done);
+};


### PR DESCRIPTION
This is much more likely to print a stack trace on failure, as opposed to "test did not call done" with no other error message.
